### PR TITLE
chore APP-3268 update android twilio chat to version 2.0.8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,6 @@ android {
 }
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.twilio:chat-android:1.0.4'
+    compile 'com.twilio:chat-android:2.0.8'
     compile "com.twilio:accessmanager-android:0.1.0"
 }

--- a/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatChannels.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatChannels.java
@@ -70,9 +70,11 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
             }
             
             @Override
-            public void onMessageUpdated(Message message) {
+            public void onMessageUpdated(Message message, Message.UpdateReason updateReason) {
                 WritableMap map = Arguments.createMap();
                 map.putString("channelSid", channelSid);
+                map.putString("updateReasonName", updateReason.name());
+                map.putInt("updateReasonValue", updateReason.getValue());
                 map.putMap("message", RCTConvert.Message(message));
                 
                 sendEvent("chatClient:channel:messageChanged", map);
@@ -97,11 +99,12 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
             }
             
             @Override
-            public void onMemberUpdated(Member member) {
+            public void onMemberUpdated(Member member, Member.UpdateReason updateReason) {
                 WritableMap map = Arguments.createMap();
                 map.putString("channelSid", channelSid);
+                map.putInt("updateReasonValue", updateReason.getValue());
                 map.putMap("member", RCTConvert.Member(member));
-                
+
                 sendEvent("chatClient:channel:memberChanged", map);
             }
             

--- a/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatClient.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatClient.java
@@ -67,11 +67,6 @@ public class RCTTwilioChatClient extends ReactContextBaseJavaModule implements C
         clientSyncStatus.put("Failed",ChatClient.SynchronizationStatus.FAILED.toString());
         constants.put("TCHClientSynchronizationStatus", clientSyncStatus);
 
-        Map<String, String> clientSyncStrategy = new HashMap<>();
-        clientSyncStrategy.put("All",ChatClient.SynchronizationStrategy.ALL.toString());
-        clientSyncStrategy.put("ChannelsList",ChatClient.SynchronizationStrategy.CHANNELS_LIST.toString());
-        constants.put("TCHClientSynchronizationStrategy", clientSyncStrategy);
-
         Map<String, String> channelOption = new HashMap<>();
         channelOption.put("FriendlyName", "friendlyName");
         channelOption.put("UniqueName", "uniqueName");


### PR DESCRIPTION
Chore to update the Android Twilio Chat library.
This required a couple of breaking changes.
- UpdateReason for messages and members
- Removed deprecated client sync strategies
- Replaces message send StatusListener with CallbackListener<Message>